### PR TITLE
Fix for DATETIMEOFFSET and DATETIME

### DIFF
--- a/datastream-jdbc-connector/src/main/java/com/linkedin/datastream/connectors/jdbc/JDBCConnectorTask.java
+++ b/datastream-jdbc-connector/src/main/java/com/linkedin/datastream/connectors/jdbc/JDBCConnectorTask.java
@@ -94,7 +94,6 @@ public class JDBCConnectorTask {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream(5 * 1024 * 1024);
         JdbcCommon.convertToAvroStream(resultSet, outputStream, true);
         GenericDatumReader<GenericRecord> reader = new GenericDatumReader<>(JdbcCommon.createSchema(resultSet));
-
         InputStream inputStream = new ByteArrayInputStream(outputStream.toByteArray());
         DataFileStream<GenericRecord> avroStream = new DataFileStream<>(inputStream, reader);
 


### PR DESCRIPTION
Copied jdbcCommon.java from Apache Nifi project to add DATETIMEOFFSET logical type support in Avro and make DATETIME type to be treated as logical type (timestamp-millis)


Important: DO NOT REPORT SECURITY ISSUES DIRECTLY ON GITHUB.  
For reporting security issues and contributing security fixes,  
please, email security@linkedin.com instead, as described in  
the contribution guidelines.

Please, take a minute to review the contribution guidelines at:  
https://github.com/linkedin/Brooklin/blob/master/CONTRIBUTING.md
