### PR TITLE
Arli BQ Decimal fix 1-0-2-18

### DIFF
--- a/datastream-bigquery/src/main/java/com/linkedin/datastream/bigquery/translator/RecordTranslator.java
+++ b/datastream-bigquery/src/main/java/com/linkedin/datastream/bigquery/translator/RecordTranslator.java
@@ -35,6 +35,11 @@ import com.google.cloud.bigquery.InsertAllRequest;
  */
 public class RecordTranslator {
 
+    /**
+     * BiqQuery restricts to 9 decimal digits of scale
+     */
+    private static final int BQ_MAX_DECIMAL_SCALE = 9;
+
     private static boolean isPrimitiveType(Schema.Type type) {
         return (type == Schema.Type.BOOLEAN ||
                 type == Schema.Type.INT ||
@@ -179,8 +184,8 @@ public class RecordTranslator {
                     final LogicalTypes.Decimal decimalType = (LogicalTypes.Decimal) avroSchema.getLogicalType();
                     BigDecimal scaledBigDecimal = new BigDecimal(new BigInteger(((ByteBuffer) record).array()), decimalType.getScale());
                     // BiqQuery restricts to 9 decimal digits of scale
-                    if (decimalType.getScale() > MAX_DECIMAL_SCALE) {
-                        scaledBigDecimal = scaledBigDecimal.setScale(MAX_DECIMAL_SCALE, RoundingMode.HALF_UP);
+                    if (decimalType.getScale() > BQ_MAX_DECIMAL_SCALE) {
+                        scaledBigDecimal = scaledBigDecimal.setScale(BQ_MAX_DECIMAL_SCALE, RoundingMode.HALF_UP);
                     }
                     result = new AbstractMap.SimpleEntry<>(name, scaledBigDecimal);
                 } else {
@@ -203,8 +208,8 @@ public class RecordTranslator {
             LogicalTypes.Decimal decimalType = (LogicalTypes.Decimal) avroSchema.getLogicalType();
             BigDecimal scaledBigDecimal = new BigDecimal(new BigInteger(((GenericFixed) record).bytes()), decimalType.getScale());
             // BiqQuery restricts to 9 decimal digits of scale
-            if (decimalType.getScale() > MAX_DECIMAL_SCALE) {
-                scaledBigDecimal = scaledBigDecimal.setScale(MAX_DECIMAL_SCALE, RoundingMode.HALF_UP);
+            if (decimalType.getScale() > BQ_MAX_DECIMAL_SCALE) {
+                scaledBigDecimal = scaledBigDecimal.setScale(BQ_MAX_DECIMAL_SCALE, RoundingMode.HALF_UP);
             }
             return new AbstractMap.SimpleEntry<>(name, scaledBigDecimal);
         } else {

--- a/datastream-bigquery/src/main/java/com/linkedin/datastream/bigquery/translator/RecordTranslator.java
+++ b/datastream-bigquery/src/main/java/com/linkedin/datastream/bigquery/translator/RecordTranslator.java
@@ -159,7 +159,7 @@ public class RecordTranslator {
                     result = new AbstractMap.SimpleEntry<>(name, LogicalTypeTranslator.translateTimeType((Integer) record, avroSchema));
                     break;
                 }
-                break;
+                //We intentionally dont want to break in this case
             case LONG:
                 if (LogicalTypeIdentifier.isTimeType(avroSchema)) {
                     result = new AbstractMap.SimpleEntry<>(name, LogicalTypeTranslator.translateTimeType((Long) record, avroSchema));
@@ -170,7 +170,7 @@ public class RecordTranslator {
                 } else {
                     result = new AbstractMap.SimpleEntry<>(name, record);
                 }
-                // We intentionally dont want to break
+                break;
             case BOOLEAN:
                 result = new AbstractMap.SimpleEntry<>(name, record);
                 break;

--- a/datastream-bigquery/src/main/java/com/linkedin/datastream/bigquery/translator/RecordTranslator.java
+++ b/datastream-bigquery/src/main/java/com/linkedin/datastream/bigquery/translator/RecordTranslator.java
@@ -170,7 +170,7 @@ public class RecordTranslator {
                 } else {
                     result = new AbstractMap.SimpleEntry<>(name, record);
                 }
-                break;
+                // We intentionally dont want to break
             case BOOLEAN:
                 result = new AbstractMap.SimpleEntry<>(name, record);
                 break;


### PR DESCRIPTION
Bound decimal scales to 9 digits as Google don't support larger digits.
https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types

**Tested in dev:** 
SQL: DEVBOSQLINTC5 csn_junk.dbo.bq_scale1
BigQuery Table: [wf-gcp-us-ae-dev.brooklin_stream_landing.bq_scale_topic1](https://console.cloud.google.com/bigquery?authuser=1&project=wf-gcp-us-ae-stg-scribe-prod&p=wf-gcp-us-ae-dev&d=brooklin_stream_landing&t=bq_scale_topic1&page=table)

Testing Procedure

1. Created a SQL table `csn_junk.dbo.bq_scale1`
`create table csn_junk.dbo.bq_scale1 (c1 int, c2 decimal(27,14), c3 decimal(10,2))`
2. Created a JDBC data stream to stream data from `csn_junk.dbo.bq_scale1` to a Kafka topic `bq_scale_topic1`
3. Created a BigQuery data stream to stream data from Kafka topic `bq_scale_topic1` into BigQeury table `wf-gcp-us-ae-dev.brooklin_stream_landing.bq_scale_topic1`

Results
SQL Table:
```
c1      c2.                     c3
2	39.54545454545454	39.55
3	31.54545454545454	34.55
```
BigQuery Table:
```
Row | c1 | c2 | c3 | __metadata.ingest_timestamp |  
-- | -- | -- | -- | -- | --
1 | 3 | 31.545454545 | 34.55 | 2020-11-17 03:14:46.087 UTC |  
2 | 2 | 39.54545455 | 39.55 | 2020-11-17 03:12:38.936 UTC
```

