### PR TITLE
Add checkpoint endpoint to restli

### DIFF
--- a/datastream-common/src/main/idl/com.linkedin.datastream.server.dms.datastream.restspec.json
+++ b/datastream-common/src/main/idl/com.linkedin.datastream.server.dms.datastream.restspec.json
@@ -93,6 +93,26 @@
           "default" : "false",
           "doc" : "whether or not to resume all datastreams within the given datastream's group"
         } ]
+      } ],
+      "subresources" : [ {
+        "name" : "checkpoint",
+        "namespace" : "com.linkedin.datastream.server.dms",
+        "path" : "/datastream/{datastreamId}/checkpoint",
+        "schema" : "com.linkedin.datastream.diagnostics.ConnectorHealth",
+        "doc" : "The Restli resource of {@link ConnectorHealth}. Used for collecting datastream checkpoint info\n about a {@link Datastream}.\n\ngenerated from: com.linkedin.datastream.server.dms.DatastreamSourceCheckpointResources",
+        "simple" : {
+          "supports" : [ "get", "update" ],
+          "methods" : [ {
+            "method" : "get",
+            "doc" : "Get source checkpoints of the parent datastream for each tasks"
+          }, {
+            "method" : "update",
+            "doc" : "Update source checkpoint on a given datastream"
+          } ],
+          "entity" : {
+            "path" : "/datastream/{datastreamId}/checkpoint"
+          }
+        }
       } ]
     }
   }

--- a/datastream-common/src/main/snapshot/com.linkedin.datastream.server.dms.datastream.snapshot.json
+++ b/datastream-common/src/main/snapshot/com.linkedin.datastream.server.dms.datastream.snapshot.json
@@ -87,6 +87,65 @@
       "doc" : "Generic metadata for Datastream (e.g. owner, expiration, etc). Metadata is stored as user defined name/value pair.",
       "optional" : true
     } ]
+  }, {
+    "type" : "record",
+    "name" : "TaskHealth",
+    "namespace" : "com.linkedin.datastream.diagnostics",
+    "doc" : "Datastream task health",
+    "fields" : [ {
+      "name" : "name",
+      "type" : "string",
+      "doc" : "name of the task."
+    }, {
+      "name" : "datastreams",
+      "type" : "string",
+      "doc" : "Name of the datastreams associated with the task."
+    }, {
+      "name" : "partitions",
+      "type" : "string",
+      "doc" : "Partitions associated with the task."
+    }, {
+      "name" : "source",
+      "type" : "string",
+      "doc" : "Source of the datastream."
+    }, {
+      "name" : "destination",
+      "type" : "string",
+      "doc" : "Destination of the datastream."
+    }, {
+      "name" : "statusCode",
+      "type" : "string",
+      "doc" : "Status code of the datastream task."
+    }, {
+      "name" : "statusMessage",
+      "type" : "string",
+      "doc" : "Status message of the datastream task."
+    }, {
+      "name" : "sourceCheckpoint",
+      "type" : "string",
+      "doc" : "Source checkpoint."
+    } ]
+  }, {
+    "type" : "record",
+    "name" : "ConnectorHealth",
+    "namespace" : "com.linkedin.datastream.diagnostics",
+    "doc" : "Datastream connector health",
+    "fields" : [ {
+      "name" : "connectorName",
+      "type" : "string",
+      "doc" : "name of the connector."
+    }, {
+      "name" : "strategy",
+      "type" : "string",
+      "doc" : "Strategy used by the connector."
+    }, {
+      "name" : "tasks",
+      "type" : {
+        "type" : "array",
+        "items" : "TaskHealth"
+      },
+      "doc" : "tasks assigned to the connector Instance."
+    } ]
   } ],
   "schema" : {
     "name" : "datastream",
@@ -183,6 +242,26 @@
             "default" : "false",
             "doc" : "whether or not to resume all datastreams within the given datastream's group"
           } ]
+        } ],
+        "subresources" : [ {
+          "name" : "checkpoint",
+          "namespace" : "com.linkedin.datastream.server.dms",
+          "path" : "/datastream/{datastreamId}/checkpoint",
+          "schema" : "com.linkedin.datastream.diagnostics.ConnectorHealth",
+          "doc" : "The Restli resource of {@link ConnectorHealth}. Used for collecting datastream checkpoint info\n about a {@link Datastream}.\n\ngenerated from: com.linkedin.datastream.server.dms.DatastreamSourceCheckpointResources",
+          "simple" : {
+            "supports" : [ "get", "update" ],
+            "methods" : [ {
+              "method" : "get",
+              "doc" : "Get source checkpoints of the parent datastream for each tasks"
+            }, {
+              "method" : "update",
+              "doc" : "Update source checkpoint on a given datastream"
+            } ],
+            "entity" : {
+              "path" : "/datastream/{datastreamId}/checkpoint"
+            }
+          }
         } ]
       }
     }

--- a/datastream-server-restli/src/main/java/com/linkedin/datastream/server/DatastreamServer.java
+++ b/datastream-server-restli/src/main/java/com/linkedin/datastream/server/DatastreamServer.java
@@ -92,6 +92,7 @@ public class DatastreamServer {
 
   private final String _csvMetricsDir;
   private final Map<String, String> _bootstrapConnectors;
+  private final Properties _properties;
 
   private Coordinator _coordinator;
   private DatastreamStore _datastreamStore;
@@ -128,6 +129,7 @@ public class DatastreamServer {
    *  </ul>
    */
   public DatastreamServer(Properties properties) throws DatastreamException {
+    _properties = properties;
     LOG.info("Start to initialize DatastreamServer. Properties: " + properties);
     LOG.info("Creating coordinator.");
     VerifiableProperties verifiableProperties = new VerifiableProperties(properties);
@@ -232,6 +234,10 @@ public class DatastreamServer {
 
   public ServerComponentHealthAggregator getServerComponentHealthAggregator() {
     return _serverComponentHealthAggregator;
+  }
+
+  public Properties getProperties() {
+    return _properties;
   }
 
   private void initializeSerde(String serdeName, Properties serdeConfig) {

--- a/datastream-server-restli/src/main/java/com/linkedin/datastream/server/diagnostics/ServerHealthResources.java
+++ b/datastream-server-restli/src/main/java/com/linkedin/datastream/server/diagnostics/ServerHealthResources.java
@@ -6,7 +6,6 @@
 package com.linkedin.datastream.server.diagnostics;
 
 
-import com.linkedin.datastream.common.DatastreamException;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -15,6 +14,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.linkedin.datastream.common.Datastream;
+import com.linkedin.datastream.common.DatastreamException;
 import com.linkedin.datastream.diagnostics.ConnectorHealth;
 import com.linkedin.datastream.diagnostics.ConnectorHealthArray;
 import com.linkedin.datastream.diagnostics.ServerHealth;
@@ -123,12 +123,10 @@ public class ServerHealthResources extends SimpleResourceTemplate<ServerHealth> 
                   (KafkaCustomCheckpointProvider) _server.getCustomCheckpointProvider(task.getDatastreams().get(0));
           taskHealth.setSourceCheckpoint(kafkaCustomCheckpointProvider.getSafeCheckpoint().toString());
           kafkaCustomCheckpointProvider.close();
-        }
-        catch (DatastreamException e) {
+        } catch (DatastreamException e) {
           _errorLogger.logAndThrowRestLiServiceException(HttpStatus.S_400_BAD_REQUEST,
                   "Failed to get checkpoints." + task.getDatastreams().get(0), e);
-        }
-        catch (Exception e) {
+        } catch (Exception e) {
           _errorLogger.logAndThrowRestLiServiceException(HttpStatus.S_500_INTERNAL_SERVER_ERROR,
                   "Failed to get checkpoints.", e);
         }

--- a/datastream-server-restli/src/main/java/com/linkedin/datastream/server/dms/DatastreamSourceCheckpointResources.java
+++ b/datastream-server-restli/src/main/java/com/linkedin/datastream/server/dms/DatastreamSourceCheckpointResources.java
@@ -114,7 +114,6 @@ public class DatastreamSourceCheckpointResources extends SimpleResourceTemplate<
 
     private ConnectorHealth buildSourceCheckpoint(Datastream datastream) {
         ConnectorHealth sourceCheckpointDetail = new ConnectorHealth();
-//        sourceCheckpointDetail.setDatastreamName(datastream.getName());
         sourceCheckpointDetail.setTasks(buildTaskSourceCheckpoint(datastream));
 
         return sourceCheckpointDetail;

--- a/datastream-server-restli/src/main/java/com/linkedin/datastream/server/dms/DatastreamSourceCheckpointResources.java
+++ b/datastream-server-restli/src/main/java/com/linkedin/datastream/server/dms/DatastreamSourceCheckpointResources.java
@@ -1,0 +1,182 @@
+/**
+ *  Copyright 2021 LinkedIn Corporation. All rights reserved.
+ *  Licensed under the BSD 2-Clause License. See the LICENSE file in the project root for license information.
+ *  See the NOTICE file in the project root for additional information regarding copyright ownership.
+ */
+package com.linkedin.datastream.server.dms;
+
+import java.util.Properties;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.linkedin.datastream.common.Datastream;
+import com.linkedin.datastream.common.DatastreamStatus;
+import com.linkedin.datastream.common.VerifiableProperties;
+import com.linkedin.datastream.diagnostics.ConnectorHealth;
+import com.linkedin.datastream.diagnostics.TaskHealth;
+import com.linkedin.datastream.diagnostics.TaskHealthArray;
+import com.linkedin.datastream.server.Coordinator;
+import com.linkedin.datastream.server.DatastreamServer;
+import com.linkedin.datastream.server.ErrorLogger;
+import com.linkedin.datastream.server.providers.KafkaCustomCheckpointProvider;
+import com.linkedin.restli.common.HttpStatus;
+import com.linkedin.restli.server.UpdateResponse;
+import com.linkedin.restli.server.annotations.RestLiSimpleResource;
+import com.linkedin.restli.server.resources.SimpleResourceTemplate;
+
+import static com.linkedin.datastream.server.DatastreamServerConfigurationConstants.CONFIG_CONNECTOR_CUSTOM_CHECKPOINTING;
+import static com.linkedin.datastream.server.DatastreamServerConfigurationConstants.CONFIG_CONNECTOR_PREFIX;
+
+/**
+ * The Restli resource of {@link ConnectorHealth}. Used for collecting datastream checkpoint info
+ * about a {@link Datastream}.
+ */
+@RestLiSimpleResource(name = "checkpoint", namespace = "com.linkedin.datastream.server.dms", parent = DatastreamResources.class)
+public class DatastreamSourceCheckpointResources extends SimpleResourceTemplate<ConnectorHealth> {
+    private static final Logger LOG = LoggerFactory.getLogger(DatastreamSourceCheckpointResources.class);
+    private static final String CONFIG_CHECKPOINT_STORE_URL = "checkpointStoreURL";
+    private static final String CONFIG_CHECKPOINT_STORE_TOPIC = "checkpointStoreTopic";
+
+    private final DatastreamStore _store;
+    private final Coordinator _coordinator;
+    private final Properties _properties;
+    private final ErrorLogger _errorLogger;
+
+
+    /**
+     * Construct an instance of DatastreamCheckpointResources
+     * @param datastreamServer Datastream server for which health data is retrieved
+     */
+    public DatastreamSourceCheckpointResources(DatastreamServer datastreamServer) {
+        _store = datastreamServer.getDatastreamStore();
+        _coordinator = datastreamServer.getCoordinator();
+        _errorLogger = new ErrorLogger(LOG, _coordinator.getInstanceName());
+        _properties = datastreamServer.getProperties();
+    }
+
+    /**
+     * Get source checkpoints of the parent datastream for each tasks
+     * @return current checkpoint
+     */
+    @Override
+    public ConnectorHealth get() {
+        String datastreamName = getParentKey();
+        try {
+            Datastream datastream = _store.getDatastream(datastreamName);
+            if (datastream == null) {
+                _errorLogger.logAndThrowRestLiServiceException(HttpStatus.S_404_NOT_FOUND,
+                        "Datastream does not exist: " + datastreamName);
+
+            }
+            return buildSourceCheckpoint(datastream);
+        } catch (Exception e) {
+            _errorLogger.logAndThrowRestLiServiceException(HttpStatus.S_500_INTERNAL_SERVER_ERROR,
+                    "Get datastream checkpoint failed for datastream: " + datastreamName, e);
+        }
+        // Returning null will automatically trigger a 404 Not Found response
+        return null;
+    }
+
+    /**
+     * Update source checkpoint on a given datastream
+     * @param input desired checkpoint value
+     * @return
+     */
+    @Override
+    public UpdateResponse update(ConnectorHealth input) {
+        String datastreamName = getParentKey();
+        Datastream datastream = _store.getDatastream(datastreamName);
+        if (datastream == null) {
+            _errorLogger.logAndThrowRestLiServiceException(HttpStatus.S_404_NOT_FOUND,
+                    "Datastream does not exist: " + datastreamName);
+        }
+        // Currently only KafkaCustomCheckpointProvider supports rewinding the checkpoint
+        if (!isCustomCheckpointing(datastream.getConnectorName())) {
+            _errorLogger.logAndThrowRestLiServiceException(HttpStatus.S_501_NOT_IMPLEMENTED,
+                    "This datastream doesn't support checkpoints to be updated.");
+        }
+        // Only paused datastreams can be updated
+        if (!DatastreamStatus.PAUSED.equals(datastream.getStatus())) {
+            _errorLogger.logAndThrowRestLiServiceException(HttpStatus.S_405_METHOD_NOT_ALLOWED,
+                    "Datastream must be in PAUSED state before updating checkpoint");
+        }
+        try {
+            // Sample SourceCheckpoint resource {"tasks":["sourceCheckpoint":"1234"]}
+            final long newCheckpoint = Long.parseLong(input.getTasks().get(0).getSourceCheckpoint());
+            getKafkaCustomCheckpointProvider(datastream).rewindTo(newCheckpoint);
+        } catch (Exception e) {
+            _errorLogger.logAndThrowRestLiServiceException(HttpStatus.S_400_BAD_REQUEST,
+                    "Could not complete datastream checkpoint update.", e);
+        }
+        return new UpdateResponse(HttpStatus.S_200_OK);
+    }
+
+    private ConnectorHealth buildSourceCheckpoint(Datastream datastream) {
+        ConnectorHealth sourceCheckpointDetail = new ConnectorHealth();
+//        sourceCheckpointDetail.setDatastreamName(datastream.getName());
+        sourceCheckpointDetail.setTasks(buildTaskSourceCheckpoint(datastream));
+
+        return sourceCheckpointDetail;
+    }
+
+    private TaskHealthArray buildTaskSourceCheckpoint(Datastream datastream) {
+        TaskHealthArray tasksSourceCheckpoint = new TaskHealthArray();
+        _coordinator.getDatastreamTasks().stream()
+                .filter(t -> t.getDatastreams().get(0).getName().equals(datastream.getName())).forEach(task -> {
+            TaskHealth taskHealth = new TaskHealth();
+            taskHealth.setName(task.getDatastreamTaskName());
+            if (isCustomCheckpointing(datastream.getConnectorName())) {
+                try {
+                    taskHealth.setSourceCheckpoint(getKafkaCustomCheckpointProvider(datastream).getSafeCheckpoint().toString());
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            } else {
+                taskHealth.setSourceCheckpoint(task.getCheckpoints().toString());
+            }
+            tasksSourceCheckpoint.add(taskHealth);
+        });
+
+        return tasksSourceCheckpoint;
+    }
+
+    private String generateJdbcCheckpointID(String datastreamName, String incrementingColumnName, String destinationTopic) {
+        String idString = datastreamName + " " + incrementingColumnName + " " + destinationTopic;
+        long hash = idString.hashCode();
+        return String.valueOf(hash > 0 ? hash : -hash);
+    }
+
+    private String getParentKey() {
+        return getContext().getPathKeys().getAsString(DatastreamResources.KEY_NAME);
+    }
+
+    /**
+     * Get instance of KafkaCustomCheckpointProvider
+     * @param datastream
+     * @return
+     */
+    public KafkaCustomCheckpointProvider getKafkaCustomCheckpointProvider(Datastream datastream) {
+        VerifiableProperties verifiableProperties = new VerifiableProperties(_properties);
+        Properties connectorProperties = verifiableProperties.getDomainProperties(CONFIG_CONNECTOR_PREFIX + datastream.getConnectorName());
+        String checkpointStoreUrl = connectorProperties.getProperty(CONFIG_CHECKPOINT_STORE_URL);
+        String checkpointStoreTopic = connectorProperties.getProperty(CONFIG_CHECKPOINT_STORE_TOPIC);
+        String jdbcIdCheckpointId = generateJdbcCheckpointID(
+                datastream.getName(),
+                datastream.getMetadata().get("incrementingColumnName"),
+                datastream.getMetadata().get("destinationTopic"));
+        return new KafkaCustomCheckpointProvider(jdbcIdCheckpointId, checkpointStoreUrl, checkpointStoreTopic);
+    }
+
+    /**
+     * Check if connector name uses custom checkpointing
+     * @param connectorName
+     * @return
+     */
+    public boolean isCustomCheckpointing(String connectorName) {
+        VerifiableProperties verifiableProperties = new VerifiableProperties(_properties);
+        Properties connectorProperties = verifiableProperties.getDomainProperties(CONFIG_CONNECTOR_PREFIX + connectorName);
+        return Boolean.parseBoolean(connectorProperties.getProperty(CONFIG_CONNECTOR_CUSTOM_CHECKPOINTING, "false"));
+    }
+
+}

--- a/datastream-server-restli/src/main/java/com/linkedin/datastream/server/dms/DatastreamSourceCheckpointResources.java
+++ b/datastream-server-restli/src/main/java/com/linkedin/datastream/server/dms/DatastreamSourceCheckpointResources.java
@@ -5,14 +5,11 @@
  */
 package com.linkedin.datastream.server.dms;
 
-import java.util.Properties;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.linkedin.datastream.common.Datastream;
 import com.linkedin.datastream.common.DatastreamStatus;
-import com.linkedin.datastream.common.VerifiableProperties;
 import com.linkedin.datastream.diagnostics.ConnectorHealth;
 import com.linkedin.datastream.diagnostics.TaskHealth;
 import com.linkedin.datastream.diagnostics.TaskHealthArray;
@@ -25,9 +22,6 @@ import com.linkedin.restli.server.UpdateResponse;
 import com.linkedin.restli.server.annotations.RestLiSimpleResource;
 import com.linkedin.restli.server.resources.SimpleResourceTemplate;
 
-import static com.linkedin.datastream.server.DatastreamServerConfigurationConstants.CONFIG_CONNECTOR_CUSTOM_CHECKPOINTING;
-import static com.linkedin.datastream.server.DatastreamServerConfigurationConstants.CONFIG_CONNECTOR_PREFIX;
-
 /**
  * The Restli resource of {@link ConnectorHealth}. Used for collecting datastream checkpoint info
  * about a {@link Datastream}.
@@ -37,10 +31,9 @@ public class DatastreamSourceCheckpointResources extends SimpleResourceTemplate<
     private static final Logger LOG = LoggerFactory.getLogger(DatastreamSourceCheckpointResources.class);
     private static final String CONFIG_CHECKPOINT_STORE_URL = "checkpointStoreURL";
     private static final String CONFIG_CHECKPOINT_STORE_TOPIC = "checkpointStoreTopic";
-
+    public final DatastreamServer _server;
     private final DatastreamStore _store;
     private final Coordinator _coordinator;
-    private final Properties _properties;
     private final ErrorLogger _errorLogger;
 
 
@@ -49,10 +42,10 @@ public class DatastreamSourceCheckpointResources extends SimpleResourceTemplate<
      * @param datastreamServer Datastream server for which health data is retrieved
      */
     public DatastreamSourceCheckpointResources(DatastreamServer datastreamServer) {
-        _store = datastreamServer.getDatastreamStore();
-        _coordinator = datastreamServer.getCoordinator();
+        _server = datastreamServer;
+        _store = _server.getDatastreamStore();
+        _coordinator = _server.getCoordinator();
         _errorLogger = new ErrorLogger(LOG, _coordinator.getInstanceName());
-        _properties = datastreamServer.getProperties();
     }
 
     /**
@@ -92,7 +85,7 @@ public class DatastreamSourceCheckpointResources extends SimpleResourceTemplate<
                     "Datastream does not exist: " + datastreamName);
         }
         // Currently only KafkaCustomCheckpointProvider supports rewinding the checkpoint
-        if (!isCustomCheckpointing(datastream.getConnectorName())) {
+        if (!_server.isCustomCheckpointing(datastream.getConnectorName())) {
             _errorLogger.logAndThrowRestLiServiceException(HttpStatus.S_501_NOT_IMPLEMENTED,
                     "This datastream doesn't support checkpoints to be updated.");
         }
@@ -104,7 +97,9 @@ public class DatastreamSourceCheckpointResources extends SimpleResourceTemplate<
         try {
             // Sample SourceCheckpoint resource {"tasks":["sourceCheckpoint":"1234"]}
             final long newCheckpoint = Long.parseLong(input.getTasks().get(0).getSourceCheckpoint());
-            getKafkaCustomCheckpointProvider(datastream).rewindTo(newCheckpoint);
+            KafkaCustomCheckpointProvider kafkaCustomCheckpointProvider = (KafkaCustomCheckpointProvider) _server.getCustomCheckpointProvider(datastream);
+            kafkaCustomCheckpointProvider.rewindTo(newCheckpoint);
+            kafkaCustomCheckpointProvider.close();
         } catch (Exception e) {
             _errorLogger.logAndThrowRestLiServiceException(HttpStatus.S_400_BAD_REQUEST,
                     "Could not complete datastream checkpoint update.", e);
@@ -125,9 +120,12 @@ public class DatastreamSourceCheckpointResources extends SimpleResourceTemplate<
                 .filter(t -> t.getDatastreams().get(0).getName().equals(datastream.getName())).forEach(task -> {
             TaskHealth taskHealth = new TaskHealth();
             taskHealth.setName(task.getDatastreamTaskName());
-            if (isCustomCheckpointing(datastream.getConnectorName())) {
+            if (_server.isCustomCheckpointing(datastream.getConnectorName())) {
                 try {
-                    taskHealth.setSourceCheckpoint(getKafkaCustomCheckpointProvider(datastream).getSafeCheckpoint().toString());
+                    KafkaCustomCheckpointProvider kafkaCustomCheckpointProvider =
+                            (KafkaCustomCheckpointProvider) _server.getCustomCheckpointProvider(task.getDatastreams().get(0));
+                    taskHealth.setSourceCheckpoint(kafkaCustomCheckpointProvider.getSafeCheckpoint().toString());
+                    kafkaCustomCheckpointProvider.close();
                 } catch (Exception e) {
                     e.printStackTrace();
                 }
@@ -140,42 +138,9 @@ public class DatastreamSourceCheckpointResources extends SimpleResourceTemplate<
         return tasksSourceCheckpoint;
     }
 
-    private String generateJdbcCheckpointID(String datastreamName, String incrementingColumnName, String destinationTopic) {
-        String idString = datastreamName + " " + incrementingColumnName + " " + destinationTopic;
-        long hash = idString.hashCode();
-        return String.valueOf(hash > 0 ? hash : -hash);
-    }
 
     private String getParentKey() {
         return getContext().getPathKeys().getAsString(DatastreamResources.KEY_NAME);
-    }
-
-    /**
-     * Get instance of KafkaCustomCheckpointProvider
-     * @param datastream
-     * @return
-     */
-    public KafkaCustomCheckpointProvider getKafkaCustomCheckpointProvider(Datastream datastream) {
-        VerifiableProperties verifiableProperties = new VerifiableProperties(_properties);
-        Properties connectorProperties = verifiableProperties.getDomainProperties(CONFIG_CONNECTOR_PREFIX + datastream.getConnectorName());
-        String checkpointStoreUrl = connectorProperties.getProperty(CONFIG_CHECKPOINT_STORE_URL);
-        String checkpointStoreTopic = connectorProperties.getProperty(CONFIG_CHECKPOINT_STORE_TOPIC);
-        String jdbcIdCheckpointId = generateJdbcCheckpointID(
-                datastream.getName(),
-                datastream.getMetadata().get("incrementingColumnName"),
-                datastream.getMetadata().get("destinationTopic"));
-        return new KafkaCustomCheckpointProvider(jdbcIdCheckpointId, checkpointStoreUrl, checkpointStoreTopic);
-    }
-
-    /**
-     * Check if connector name uses custom checkpointing
-     * @param connectorName
-     * @return
-     */
-    public boolean isCustomCheckpointing(String connectorName) {
-        VerifiableProperties verifiableProperties = new VerifiableProperties(_properties);
-        Properties connectorProperties = verifiableProperties.getDomainProperties(CONFIG_CONNECTOR_PREFIX + connectorName);
-        return Boolean.parseBoolean(connectorProperties.getProperty(CONFIG_CONNECTOR_CUSTOM_CHECKPOINTING, "false"));
     }
 
 }

--- a/gradle/maven.gradle
+++ b/gradle/maven.gradle
@@ -1,5 +1,5 @@
 allprojects {
-  version = "1.0.2-18-SNAPSHOT"
+  version = "1.0.2-19-SNAPSHOT"
 }
 
 subprojects {


### PR DESCRIPTION

Add a REST endpoint to view and update the current checkpoint of a given datastream.

Only JDBC connector datastreams allow the checkpoint to be updated.

Tested:
GET
curl -v bcstp-iad1-g1-1.c.wf-gcp-us-bigdata-dev.internal:32311/datastream/jdbcDemo1b/checkpoint

PUT
curl -X PUT -d '{"tasks":[{"sourceCheckpoint":"102"}]}' -v bcstp-iad1-g1-1.c.wf-gcp-us-bigdata-dev.internal:32311/datastream/jdbcDemo1b/checkpoint