### PR TITLE
Fixed a bug where a BigQuery Transport Provider is closed prematurely…

### DIFF
--- a/datastream-bigquery/src/main/java/com/linkedin/datastream/bigquery/BigqueryTransportProviderAdmin.java
+++ b/datastream-bigquery/src/main/java/com/linkedin/datastream/bigquery/BigqueryTransportProviderAdmin.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -67,9 +68,9 @@ public class BigqueryTransportProviderAdmin implements TransportProviderAdmin {
     private final BigqueryDatastreamConfigurationFactory _bigqueryDatastreamConfigurationFactory;
 
     private final Map<String, BigquerySchemaEvolver> _bigquerySchemaEvolverMap;
-    private final Map<BigqueryDatastreamDestination, BigqueryDatastreamConfiguration> _datastreamConfigByDestination;
-    private final Map<Datastream, BigqueryTransportProvider> _datastreamTransportProvider;
-    private final Map<BigqueryTransportProvider, Set<DatastreamTask>> _transportProviderTasks;
+    private final ConcurrentMap<BigqueryDatastreamDestination, BigqueryDatastreamConfiguration> _datastreamConfigByDestination;
+    private final ConcurrentMap<Datastream, BigqueryTransportProvider> _datastreamTransportProvider;
+    private final ConcurrentMap<BigqueryTransportProvider, ConcurrentHashMap.KeySetView<DatastreamTask, Boolean>> _transportProviderTasks;
 
     private final Pattern _legacyDatastreamDestinationConnectionStringPattern;
 
@@ -80,7 +81,7 @@ public class BigqueryTransportProviderAdmin implements TransportProviderAdmin {
      */
     public BigqueryTransportProviderAdmin(final BigqueryBufferedTransportProvider bufferedTransportProvider,
                                           final BigquerySchemaEvolver defaultSchemaEvolver,
-                                          final Map<BigqueryDatastreamDestination, BigqueryDatastreamConfiguration> datastreamConfigByDestination,
+                                          final ConcurrentMap<BigqueryDatastreamDestination, BigqueryDatastreamConfiguration> datastreamConfigByDestination,
                                           final Map<String, BigquerySchemaEvolver> bigquerySchemaEvolverMap,
                                           final BigqueryTransportProviderFactory bigqueryTransportProviderFactory,
                                           final BigqueryDatastreamConfigurationFactory bigqueryDatastreamConfigurationFactory,
@@ -116,13 +117,14 @@ public class BigqueryTransportProviderAdmin implements TransportProviderAdmin {
                 throw new DatastreamRuntimeException("Unable to assign invalid datastream", e);
             }
         }
-        return _datastreamTransportProvider.computeIfAbsent(datastream, d -> {
+
+        final BigqueryTransportProvider transportProvider = _datastreamTransportProvider.computeIfAbsent(datastream, d -> {
             final BigqueryDatastreamConfiguration configuration = getConfigurationFromDatastream(d);
-            final BigqueryTransportProvider transportProvider =  _bigqueryTransportProviderFactory.createTransportProvider(_bufferedTransportProvider,
+            return  _bigqueryTransportProviderFactory.createTransportProvider(_bufferedTransportProvider,
                     configuration.getValueSerializer(), configuration.getValueDeserializer(), configuration, _datastreamConfigByDestination);
-            _transportProviderTasks.computeIfAbsent(transportProvider, tp -> ConcurrentHashMap.newKeySet()).add(task);
-            return transportProvider;
         });
+        _transportProviderTasks.computeIfAbsent(transportProvider, tp -> ConcurrentHashMap.newKeySet()).add(task);
+        return transportProvider;
     }
 
     Map<Datastream, BigqueryTransportProvider> getDatastreamTransportProviders() {
@@ -137,16 +139,23 @@ public class BigqueryTransportProviderAdmin implements TransportProviderAdmin {
     public void unassignTransportProvider(final DatastreamTask task) {
         // Assume that the task has a single datastream
         final Datastream datastream = task.getDatastreams().get(0);
-        _datastreamTransportProvider.computeIfPresent(datastream, (d, transportProvider) ->
-            Optional.ofNullable(_transportProviderTasks.computeIfPresent(transportProvider, (tp, tasks) -> {
+        _datastreamTransportProvider.computeIfPresent(datastream, (d, transportProvider) -> {
+            // Remove the task from the transport provider tasks set and clear out the mapping if the tasks set is empty
+            final Set<DatastreamTask> remainingTransportProviderTasks = _transportProviderTasks.computeIfPresent(transportProvider, (tp, tasks) -> {
                 tasks.remove(task);
                 return tasks.isEmpty() ? null : tasks;
-            })).map(s -> transportProvider).orElseGet(() -> {
-                transportProvider.getDestinations().forEach(_datastreamConfigByDestination::remove);
+            });
+
+            // If the transport provider has no more tasks assigned, then close and remove the mapping, else retain the mapping
+            if (remainingTransportProviderTasks == null || remainingTransportProviderTasks.isEmpty()) {
+                // Do not remove destination configurations as we do not know when the last event is committed
+                //transportProvider.getDestinations().forEach(_datastreamConfigByDestination::remove);
                 transportProvider.close();
                 return null;
-            })
-        );
+            } else {
+                return transportProvider;
+            }
+        });
     }
 
     @Override

--- a/datastream-bigquery/src/main/java/com/linkedin/datastream/bigquery/BigqueryTransportProviderAdminFactory.java
+++ b/datastream-bigquery/src/main/java/com/linkedin/datastream/bigquery/BigqueryTransportProviderAdminFactory.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -59,7 +60,7 @@ public class BigqueryTransportProviderAdminFactory implements TransportProviderA
         // Create a map to define datastream destination to configuration mappings and share with multiple components.
         // Datastream destination to configuration mappings are initialized when new datastreams are created or assigned for processing.
         // TODO: potentially replace the shared map with a datastream configuration registry implementation
-        final Map<BigqueryDatastreamDestination, BigqueryDatastreamConfiguration> datastreamConfigByDestination = new ConcurrentHashMap<>();
+        final ConcurrentMap<BigqueryDatastreamDestination, BigqueryDatastreamConfiguration> datastreamConfigByDestination = new ConcurrentHashMap<>();
         final String committerProjectId;
         final BigqueryBatchCommitter committer;
         {

--- a/datastream-bigquery/src/main/java/com/linkedin/datastream/bigquery/BigqueryTransportProviderFactory.java
+++ b/datastream-bigquery/src/main/java/com/linkedin/datastream/bigquery/BigqueryTransportProviderFactory.java
@@ -6,7 +6,7 @@
 
 package com.linkedin.datastream.bigquery;
 
-import java.util.Map;
+import java.util.concurrent.ConcurrentMap;
 
 import com.linkedin.datastream.serde.Deserializer;
 
@@ -28,7 +28,8 @@ public class BigqueryTransportProviderFactory {
                                                              final Serializer valueSerializer,
                                                              final Deserializer valueDeserializer,
                                                              final BigqueryDatastreamConfiguration datastreamConfiguration,
-                                                             final Map<BigqueryDatastreamDestination, BigqueryDatastreamConfiguration> destinationConfigs) {
+                                                             final ConcurrentMap<BigqueryDatastreamDestination, BigqueryDatastreamConfiguration>
+                                                                     destinationConfigs) {
         return new BigqueryTransportProvider(bufferedTransportProvider, valueSerializer, valueDeserializer,
                 datastreamConfiguration, destinationConfigs);
     }

--- a/datastream-bigquery/src/test/java/com/linkedin/datastream/bigquery/BigqueryDatastreamConfigurationTests.java
+++ b/datastream-bigquery/src/test/java/com/linkedin/datastream/bigquery/BigqueryDatastreamConfigurationTests.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2020 Wayfair LLC. All rights reserved.
+ *  Licensed under the BSD 2-Clause License. See the LICENSE file in the project root for license information.
+ *  See the NOTICE file in the project root for additional information regarding copyright ownership.
+ */
+
+package com.linkedin.datastream.bigquery;
+
+import java.util.List;
+
+import org.apache.avro.Schema;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableList;
+
+import com.linkedin.datastream.bigquery.schema.BigquerySchemaEvolver;
+import com.linkedin.datastream.serde.Deserializer;
+
+
+import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertEquals;
+
+public class BigqueryDatastreamConfigurationTests {
+
+    @Test
+    public void testEquals() {
+        final BigqueryDatastreamDestination destination = new BigqueryDatastreamDestination("project", "dataset", "destination");
+        final BigquerySchemaEvolver schemaEvolver = mock(BigquerySchemaEvolver.class);
+        final boolean createDestinationTable = true;
+        final Deserializer deserializer = mock(Deserializer.class);
+        final Serializer serializer = mock(Serializer.class);
+        final long partitionExpirationDays = 5;
+        final List<BigqueryLabel> labels = ImmutableList.of(BigqueryLabel.of("test"));
+        final Schema fixedSchema = mock(Schema.class);
+        final BigqueryDatastreamDestination deadLetterTableDestination = new BigqueryDatastreamDestination("project", "dataset", "dlq");
+        final BigqueryDatastreamConfiguration deadLetterTableConfig = BigqueryDatastreamConfiguration
+                .builder(deadLetterTableDestination, schemaEvolver, createDestinationTable, deserializer, serializer)
+                .build();
+        final BigqueryDatastreamConfiguration config = BigqueryDatastreamConfiguration.builder(destination, schemaEvolver, createDestinationTable, deserializer,
+                serializer)
+                .withPartitionExpirationDays(partitionExpirationDays)
+                .withLabels(labels)
+                .withFixedSchema(fixedSchema)
+                .withDeadLetterTableConfiguration(deadLetterTableConfig)
+                .build();
+
+        assertEquals(BigqueryDatastreamConfiguration.builder(destination, schemaEvolver, createDestinationTable, deserializer,
+                serializer)
+                .withPartitionExpirationDays(partitionExpirationDays)
+                .withLabels(labels)
+                .withFixedSchema(fixedSchema)
+                .withDeadLetterTableConfiguration(BigqueryDatastreamConfiguration
+                        .builder(deadLetterTableDestination, schemaEvolver, createDestinationTable, deserializer, serializer)
+                        .build())
+                .build(), config);
+    }
+
+    @Test
+    public void testHashCode() {
+        final BigqueryDatastreamDestination destination = new BigqueryDatastreamDestination("project", "dataset", "destination");
+        final BigquerySchemaEvolver schemaEvolver = mock(BigquerySchemaEvolver.class);
+        final boolean createDestinationTable = true;
+        final Deserializer deserializer = mock(Deserializer.class);
+        final Serializer serializer = mock(Serializer.class);
+        final long partitionExpirationDays = 5;
+        final List<BigqueryLabel> labels = ImmutableList.of(BigqueryLabel.of("test"));
+        final Schema fixedSchema = mock(Schema.class);
+        final BigqueryDatastreamDestination deadLetterTableDestination = new BigqueryDatastreamDestination("project", "dataset", "dlq");
+        final BigqueryDatastreamConfiguration deadLetterTableConfig = BigqueryDatastreamConfiguration
+                .builder(deadLetterTableDestination, schemaEvolver, createDestinationTable, deserializer, serializer)
+                .build();
+        final BigqueryDatastreamConfiguration config = BigqueryDatastreamConfiguration.builder(destination, schemaEvolver, createDestinationTable, deserializer,
+                serializer)
+                .withPartitionExpirationDays(partitionExpirationDays)
+                .withLabels(labels)
+                .withFixedSchema(fixedSchema)
+                .withDeadLetterTableConfiguration(deadLetterTableConfig)
+                .build();
+
+        assertEquals(BigqueryDatastreamConfiguration.builder(destination, schemaEvolver, createDestinationTable, deserializer,
+                serializer)
+                .withPartitionExpirationDays(partitionExpirationDays)
+                .withLabels(labels)
+                .withFixedSchema(fixedSchema)
+                .withDeadLetterTableConfiguration(BigqueryDatastreamConfiguration
+                        .builder(deadLetterTableDestination, schemaEvolver, createDestinationTable, deserializer, serializer)
+                        .build())
+                .build().hashCode(), config.hashCode());
+    }
+}

--- a/datastream-bigquery/src/test/java/com/linkedin/datastream/bigquery/BigqueryDatastreamDestinationTests.java
+++ b/datastream-bigquery/src/test/java/com/linkedin/datastream/bigquery/BigqueryDatastreamDestinationTests.java
@@ -6,10 +6,12 @@
 package com.linkedin.datastream.bigquery;
 
 import java.net.URI;
+import java.util.Objects;
 
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 public class BigqueryDatastreamDestinationTests {
 
@@ -36,6 +38,30 @@ public class BigqueryDatastreamDestinationTests {
                 BigqueryDatastreamDestination.parse("brooklin-bigquery://project_name.dataset.test.topic.with.period"),
                 destination
         );
+    }
+
+    @Test
+    public void testEquals() {
+        final String project = "project";
+        final String dataset = "dataset";
+        final String destinationName = "destination";
+        final BigqueryDatastreamDestination destination = new BigqueryDatastreamDestination(project, dataset, destinationName);
+        final String url = destination.toString();
+
+        assertEquals(new BigqueryDatastreamDestination(project, dataset, destinationName), destination);
+        assertEquals(BigqueryDatastreamDestination.parse(url), destination);
+    }
+
+    @Test
+    public void testHashCode() {
+        final String project = "project";
+        final String dataset = "dataset";
+        final String destinationName = "destination";
+        final BigqueryDatastreamDestination destination = new BigqueryDatastreamDestination(project, dataset, destinationName);
+        final String url = destination.toString();
+
+        assertEquals(new BigqueryDatastreamDestination(project, dataset, destinationName).hashCode(), destination.hashCode());
+        assertEquals(BigqueryDatastreamDestination.parse(url).hashCode(), destination.hashCode());
     }
 
 }

--- a/datastream-bigquery/src/test/java/com/linkedin/datastream/bigquery/BigqueryTransportProviderTests.java
+++ b/datastream-bigquery/src/test/java/com/linkedin/datastream/bigquery/BigqueryTransportProviderTests.java
@@ -55,11 +55,12 @@ import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -119,7 +120,7 @@ public class BigqueryTransportProviderTests {
         final String topicName = getUniqueTopicName();
         final String tableName = BigqueryBatchCommitter.sanitizeTableName(topicName);
         final BigqueryDatastreamDestination destination = new BigqueryDatastreamDestination(projectId, datasetName, tableName);
-        final Map<BigqueryDatastreamDestination, BigqueryDatastreamConfiguration> destConfigs = new HashMap<>();
+        final ConcurrentMap<BigqueryDatastreamDestination, BigqueryDatastreamConfiguration> destConfigs = new ConcurrentHashMap<>();
         final BigqueryDatastreamConfiguration config = BigqueryDatastreamConfiguration.builder(
                 destination, BigquerySchemaEvolverFactory.createBigquerySchemaEvolver(BigquerySchemaEvolverType.dynamic), true,
                 valueDeserializer, valueSerializer).build();
@@ -218,7 +219,7 @@ public class BigqueryTransportProviderTests {
         final BigqueryDatastreamConfiguration config = BigqueryDatastreamConfiguration.builder(
                 destination, BigquerySchemaEvolverFactory.createBigquerySchemaEvolver(BigquerySchemaEvolverType.dynamic), true,
                 valueDeserializer, valueSerializer).build();
-        final Map<BigqueryDatastreamDestination, BigqueryDatastreamConfiguration> destConfigs = new HashMap<>();
+        final ConcurrentMap<BigqueryDatastreamDestination, BigqueryDatastreamConfiguration> destConfigs = new ConcurrentHashMap<>();
         destConfigs.put(destination, config);
 
         final BigqueryBatchCommitter committer = new BigqueryBatchCommitter(bigQuery, 1, destConfigs);
@@ -319,7 +320,7 @@ public class BigqueryTransportProviderTests {
         final String topicName = getUniqueTopicName();
         final String tableName = BigqueryBatchCommitter.sanitizeTableName(topicName);
         final BigqueryDatastreamDestination destination = new BigqueryDatastreamDestination(projectId, datasetName, tableName);
-        final Map<BigqueryDatastreamDestination, BigqueryDatastreamConfiguration> destConfigs = new HashMap<>();
+        final ConcurrentMap<BigqueryDatastreamDestination, BigqueryDatastreamConfiguration> destConfigs = new ConcurrentHashMap<>();
         final BigqueryDatastreamConfiguration config = BigqueryDatastreamConfiguration.builder(
                 destination, BigquerySchemaEvolverFactory.createBigquerySchemaEvolver(BigquerySchemaEvolverType.dynamic), true,
                 valueDeserializer, valueSerializer).build();
@@ -417,7 +418,7 @@ public class BigqueryTransportProviderTests {
         final BigqueryDatastreamDestination destination = new BigqueryDatastreamDestination(projectId, datasetName, tableName);
         final TableId exceptionsTableId = TableId.of(projectId, datasetName, topicName + "_exceptions");
         final BigqueryDatastreamDestination deadLetterTableDestination = new BigqueryDatastreamDestination(projectId, datasetName, exceptionsTableId.getTable());
-        final Map<BigqueryDatastreamDestination, BigqueryDatastreamConfiguration> destConfigs = new HashMap<>();
+        final ConcurrentMap<BigqueryDatastreamDestination, BigqueryDatastreamConfiguration> destConfigs = new ConcurrentHashMap<>();
         final BigqueryDatastreamConfiguration config = BigqueryDatastreamConfiguration.builder(
                 destination, BigquerySchemaEvolverFactory.createBigquerySchemaEvolver(BigquerySchemaEvolverType.dynamic), true,
                 valueDeserializer, valueSerializer)
@@ -559,7 +560,7 @@ public class BigqueryTransportProviderTests {
         final BigqueryDatastreamDestination destination = new BigqueryDatastreamDestination(projectId, datasetName, tableName);
         final TableId exceptionsTableId = TableId.of(projectId, datasetName, topicName + "_exceptions");
         final BigqueryDatastreamDestination deadLetterTableDestination = new BigqueryDatastreamDestination(projectId, datasetName, exceptionsTableId.getTable());
-        final Map<BigqueryDatastreamDestination, BigqueryDatastreamConfiguration> destConfigs = new HashMap<>();
+        final ConcurrentMap<BigqueryDatastreamDestination, BigqueryDatastreamConfiguration> destConfigs = new ConcurrentHashMap<>();
         final BigqueryDatastreamConfiguration config = BigqueryDatastreamConfiguration.builder(
                 destination, BigquerySchemaEvolverFactory.createBigquerySchemaEvolver(BigquerySchemaEvolverType.dynamic), true,
                 valueDeserializer, valueSerializer


### PR DESCRIPTION
… when a DatastreamTask is unassigned

Also fixed a potential issue where a destination to config mapping is removed before downstream
batch processing is complete.

Important: DO NOT REPORT SECURITY ISSUES DIRECTLY ON GITHUB.  
For reporting security issues and contributing security fixes,  
please, email security@linkedin.com instead, as described in  
the contribution guidelines.

Please, take a minute to review the contribution guidelines at:  
https://github.com/linkedin/Brooklin/blob/master/CONTRIBUTING.md
